### PR TITLE
Add real-time Streamlit dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project is a complete data pipeline for simulating, processing, and storing
 - **FastAPI** (`api`): Generates synthetic sales data via an HTTP endpoint (`/data`).
 - **PostgreSQL** (`postgres`): Stores the processed sales data in a dedicated schema and table.
 - **Apache Airflow** (`airflow`): Orchestrates the ETL pipeline, extracting data from the API, transforming it with pandas, and loading it into PostgreSQL.
+- **Streamlit Dashboard** (`dashboard`): Visualizes the processed sales data from PostgreSQL in real time.
 
 ## How It Works
 
@@ -37,6 +38,10 @@ All components are orchestrated using Docker Compose, which automatically builds
 ├── api
 │   ├── Dockerfile
 │   └── main.py
+├── dashboard
+│   ├── Dockerfile
+│   ├── app.py
+│   └── requirements.txt
 ├── db_init
 │   └── init.sql
 ├── docker-compose.yaml
@@ -66,6 +71,7 @@ All components are orchestrated using Docker Compose, which automatically builds
    - **Airflow Web UI**: [http://localhost:8080](http://localhost:8080)
    - **FastAPI Endpoint**: [http://localhost:8000/data](http://localhost:8000/data)
    - **PostgreSQL**: Host: `localhost`, port: `5432`, user: `admin`, password: `admin`, database: `pipeline_db`
+   - **Streamlit Dashboard**: [http://localhost:8501](http://localhost:8501)
 
    - **Airflow Login:** The default username is `admin`. The password is automatically generated and printed in the Airflow container logs when the service starts. Check the terminal output for this line (which should be one of the first lines from the airflow service):
       ```

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py ./
+
+EXPOSE 8501
+
+CMD ["streamlit", "run", "app.py", "--server.address=0.0.0.0"]

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,24 @@
+import time
+import pandas as pd
+import streamlit as st
+from sqlalchemy import create_engine
+
+# Connection using service name from docker-compose
+engine = create_engine('postgresql+psycopg2://admin:admin@postgres:5432/pipeline_db')
+
+st.set_page_config(page_title='Sales Dashboard', layout='wide')
+st.title('Real-Time Sales Dashboard')
+
+placeholder = st.empty()
+
+refresh_interval = 10  # seconds
+
+while True:
+    df = pd.read_sql('SELECT * FROM treated.sales ORDER BY datetime DESC LIMIT 1000', engine)
+
+    with placeholder.container():
+        st.metric('Total Revenue', f"${df['revenue'].sum():,.2f}")
+        st.line_chart(df.sort_values('datetime').set_index('datetime')['revenue'])
+        st.dataframe(df)
+
+    time.sleep(refresh_interval)

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+pandas
+sqlalchemy
+psycopg2-binary

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,6 +51,18 @@ services:
         api:
             condition: service_started
 
+  dashboard:
+    build:
+      context: ./dashboard
+    container_name: dashboard
+    ports:
+      - "8501:8501"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - etl_net
+
 volumes:
   pgdata:
 


### PR DESCRIPTION
## Summary
- add Streamlit app that reads from PostgreSQL and updates automatically
- run dashboard in new Docker service
- document new dashboard in README

## Testing
- `python -m py_compile dashboard/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b5125ff88322858441673bd92cf1